### PR TITLE
refactor: simplify installation commands and remove duplicate imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,13 @@ Run vue example locally:
 3. run command:
 
 ```bash
-pnpm vue-example:install
+pnpm install
 pnpm vue-example:dev
 ```
 
 ## Install SDK
 
 ```bash
-npm install @refore/copy-to-design-sdk
-yarn add @refore/copy-to-design-sdk
 pnpm install @refore/copy-to-design-sdk
 ```
 

--- a/example/vue/src/components/export/ExportDialog.vue
+++ b/example/vue/src/components/export/ExportDialog.vue
@@ -6,7 +6,6 @@ import SuccessAnimation from '../animation/SuccessAnimation.vue';
 import type { ButtonOption } from '../selectable-button/types';
 import { Dialog, DialogContent } from '../ui/dialog';
 import type { ExportContent } from './type';
-import { Button } from '../ui/button';
 import { DESIGN_APPS } from './type';
 import { Button } from '../ui/button';
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint src",
     "prepublishOnly": "pnpm run build",
     "release": "semantic-release --no-ci",
-    "vue-example:dev": "pnpm --filter vue-example dev",
-    "vue-example:install": "pnpm install && pnpm --filter vue-example install"
+    "postinstall": "pnpm --filter vue-example install",
+    "vue-example:dev": "pnpm --filter vue-example dev"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- Replace separate vue-example:install command with postinstall hook
- Remove redundant npm/yarn install instructions
- Clean up duplicate Button import in ExportDialog

