### PR TITLE
fix(vue-example): adjust the style of example selector and tab switcher

### DIFF
--- a/example/vue/src/App.vue
+++ b/example/vue/src/App.vue
@@ -23,8 +23,6 @@ const combined_content = computed(() => inputs.value.map(i => i.content).join(''
 
 // 视图模式切换
 const viewMode = ref('preview');
-const isOpen = ref(false);
-
 
 onMounted(async () => {
   try {
@@ -72,8 +70,8 @@ onMounted(async () => {
 
         <div class="flex items-center space-x-2">
           <ExampleSelector v-model="page" :inputs="inputs" />
-          <Tabs v-model="viewMode" class="ml-3">
-            <TabsList>
+          <Tabs v-model="viewMode" class="ml-4">
+            <TabsList class="grid w-full grid-cols-2 px-1">
               <TabsTrigger value="preview">preview</TabsTrigger>
               <TabsTrigger value="code">code</TabsTrigger>
             </TabsList>

--- a/example/vue/src/components/example-selector/example-selector.vue
+++ b/example/vue/src/components/example-selector/example-selector.vue
@@ -5,41 +5,40 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { ChevronDown } from 'lucide-vue-next'
 
 defineProps<{
-  inputs: ExampleInput[]
-  modelValue: number
-}>()
+  inputs: ExampleInput[];
+  modelValue: number;
+}>();
 
 const emit = defineEmits<{
-  (e: 'update:modelValue', value: number): void
-}>()
+  (e: 'update:modelValue', value: number): void;
+}>();
 
-const isOpen = ref(false)
+const isOpen = ref(false);
 
 const handleClick = (idx: number) => {
-  emit('update:modelValue', idx)
-  isOpen.value = false
-}
+  emit('update:modelValue', idx);
+  isOpen.value = false;
+};
 </script>
 
 <template>
   <DropdownMenu v-model:open="isOpen">
     <DropdownMenuTrigger
-        class="bg-background text-foreground rounded-lg border shadow px-2 py-1 text-sm flex items-center justify-between hover:bg-gray-50"
+      class="w-32 bg-background text-foreground rounded-lg border shadow px-2 py-1 text-sm flex items-center justify-between hover:bg-gray-50"
     >
-      {{ inputs[modelValue]?.label || 'Select' }}
+      <a class="ml-1 font-medium"> {{ inputs[modelValue]?.label || 'Select' }} </a>
       <ChevronDown
-          class="ml-2 h-3 w-3 text-gray-600 transition-transform duration-200"
-          :class="{ 'rotate-180 transform': isOpen }"
+        class="ml-2 h-3 w-3 text-gray-600 transition-transform duration-200"
+        :class="{ 'rotate-180 transform': isOpen }"
       />
     </DropdownMenuTrigger>
 
-    <DropdownMenuContent>
+    <DropdownMenuContent align="center">
       <DropdownMenuItem
-          v-for="(opt, idx) in inputs"
-          :key="idx"
-          class="h-6 rounded px-2 hover:bg-gray-50 mt-1"
-          :class="{ 'bg-gray-200': idx === modelValue }"
-          @click="handleClick(idx)"
+        v-for="(opt, idx) in inputs"
+        :key="idx"
+        :class="['h-6 rounded px-2 mt-1', idx === modelValue ? 'bg-gray-200 pointer-events-none' : 'hover:bg-gray-50']"
+        @click="handleClick(idx)"
       >
         {{ opt.label }}
       </DropdownMenuItem>


### PR DESCRIPTION
Fixed some styling issue on vue example



<img width="3840" height="2160" alt="Screenshot From 2025-08-16 22-58-37" src="https://github.com/user-attachments/assets/43276d93-828b-45f3-8565-940726ce8b1b" />
<img width="801" height="302" alt="Screenshot From 2025-08-16 22-42-57" src="https://github.com/user-attachments/assets/1107ea0d-42aa-45b4-ac80-3c36d0de9337" />
<img width="740" height="116" alt="Screenshot From 2025-08-16 22-34-31" src="https://github.com/user-attachments/assets/71e20510-2286-488c-b2b6-3b5d11daa5c5" />
